### PR TITLE
Improve travis configuration to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: android
+
+env:
+  global:
+    - ADB_INSTALL_TIMEOUT=8
+
+  matrix:
+    - ANDROID_TARGET=15 ANDROID_ABI=default/armeabi-v7a
+    - ANDROID_TARGET=21 ANDROID_ABI=default/armeabi-v7a
+
 android:
   components:
   - platform-tools
@@ -6,8 +15,15 @@ android:
   - android-23
   - build-tools-23.0.1
 
+before_script:
+  - echo no | android create avd --force -n test -t android-$ANDROID_TARGET --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
 before_install:
- - chmod +x gradlew
+  - chmod +x gradlew
 
 script:
-  - ./gradlew clean build
+  - ./gradlew clean assemble
+  - ./gradlew connectedAndroidTest


### PR DESCRIPTION
This PR improves the travis configuration to run the Android tests instead of just make the OneDrive SDK for Android build.
