### PR TITLE
Support for Android SDK 10 (Gingerbread)

### DIFF
--- a/onedrivesdk/build.gradle
+++ b/onedrivesdk/build.gradle
@@ -14,7 +14,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 10
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/onedrivesdk/src/main/AndroidManifest.xml
+++ b/onedrivesdk/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
-<manifest package="com.microsoft.onedrivesdk" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    package="com.microsoft.onedrivesdk"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-sdk tools:overrideLibrary="com.microsoft.services.msa, com.microsoft.aad.adal" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
     <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS"/>


### PR DESCRIPTION
Update the manifest merging logic to use the provided min sdk version
instead of falling back on the highest version from the dependent packages

Note: When you import the MSA or ADAL libraries in your application you
will also need to include <uses-sdk tools:overrideLibrary="..." /> for the
authentication libraries that you use

Fixes #5
