### PR TITLE
Prevent authentication callback from being reused

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,5 @@ org.gradle.jvmargs=-XX:MaxPermSize=512m
 mavenRepoUrl    = https://api.bintray.com/maven/onedrive/Maven/onedrive-sdk-android
 mavenGroupId    = com.onedrive.sdk
 mavenArtifactId = onedrive-sdk-android
-mavenVersion    = 1.0.0
+mavenVersion    = 1.0.1
 nightliesUrl    = http://dl.bintray.com/onedrive/Maven

--- a/onedrivesdk/src/main/java/com/onedrive/sdk/authentication/MSAAuthenticator.java
+++ b/onedrivesdk/src/main/java/com/onedrive/sdk/authentication/MSAAuthenticator.java
@@ -166,14 +166,12 @@ public abstract class MSAAuthenticator implements IAuthenticator {
             public void onAuthComplete(final LiveStatus liveStatus,
                                        final LiveConnectSession liveConnectSession,
                                        final Object o) {
-                if (liveStatus != LiveStatus.CONNECTED) {
-                    error.set(new ClientAuthenticatorException("Was unable to connect to the MSA login session",
-                                                               OneDriveErrorCodes.AuthenticationFailure));
-                    mLogger.logError(error.get().getMessage(), error.get());
+                if (liveStatus == LiveStatus.NOT_CONNECTED) {
+                    mLogger.logDebug("Received invalid login failure from silent authentication with MSA, ignoring.");
+                } else {
+                    mLogger.logDebug("Successful interactive login");
+                    waiter.signal();
                 }
-
-                mLogger.logDebug("Successful login");
-                waiter.signal();
             }
 
             @Override
@@ -256,13 +254,13 @@ public abstract class MSAAuthenticator implements IAuthenticator {
             public void onAuthComplete(final LiveStatus liveStatus,
                                        final LiveConnectSession liveConnectSession,
                                        final Object o) {
-                if (liveStatus != LiveStatus.CONNECTED) {
-                    error.set(new ClientAuthenticatorException("Was unable to connect to the MSA login session",
-                                                               OneDriveErrorCodes.AuthenticationFailure));
+                if (liveStatus == LiveStatus.NOT_CONNECTED) {
+                    error.set(new ClientAuthenticatorException("Failed silent login, interactive login required",
+                            OneDriveErrorCodes.AuthenticationFailure));
                     mLogger.logError(error.get().getMessage(), error.get());
+                } else {
+                    mLogger.logDebug("Successful silent login");
                 }
-
-                mLogger.logDebug("Successful silent login");
                 loginSilentWaiter.signal();
             }
 


### PR DESCRIPTION
Within the MSA flow there are scenarios where an authentication callback
would recieve a failure, and then a success message due to how slient
authentication is treated during an interactive login.  Changing the SDK
to handle this scenario and isolate this strange case so callbacks should
only be acted on once.
