### PR TITLE
Fix wrong variable name in document

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -134,5 +134,5 @@ oneDriveClient
     .getItems(parentId)
     .getChildren()
     .buildRequest()
-    .create(newItem, callback);
+    .create(folderToCreate, callback);
 ```


### PR DESCRIPTION
Found the variable declared before in document is not passed in callback function later, which could be misleading.
