### PR TITLE
Change when OneDriveFatalServiceExceptions are created

### DIFF
--- a/onedrivesdk/src/main/java/com/onedrive/sdk/http/OneDriveFatalServiceException.java
+++ b/onedrivesdk/src/main/java/com/onedrive/sdk/http/OneDriveFatalServiceException.java
@@ -23,6 +23,7 @@
 package com.onedrive.sdk.http;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * An unexpected exception from the OneDrive service.
@@ -61,10 +62,20 @@ public class OneDriveFatalServiceException extends OneDriveServiceException {
         //noinspection StringBufferReplaceableByString
         final StringBuilder sb = new StringBuilder();
         sb.append("[This is an unexpected error from OneDrive, please report this at ")
-                .append(SDK_BUG_URL)
-                .append(']')
-                .append(NEW_LINE)
-                .append(super.getMessage(true));
+          .append(SDK_BUG_URL);
+
+        // Add the unique error identifier if it exists
+        for (final String header : getResponseHeaders()) {
+            if (header.toLowerCase(Locale.ROOT).startsWith(X_THROWSITE)) {
+                sb.append(", ID = ")
+                  .append(header);
+                break;
+            }
+        }
+
+        sb.append(']')
+          .append(NEW_LINE)
+          .append(super.getMessage(true));
         return sb.toString();
     }
 }

--- a/onedrivesdk/src/main/java/com/onedrive/sdk/http/OneDriveServiceException.java
+++ b/onedrivesdk/src/main/java/com/onedrive/sdk/http/OneDriveServiceException.java
@@ -72,6 +72,16 @@ public class OneDriveServiceException extends ClientException {
     public static final int INTERNAL_SERVER_ERROR = 500;
 
     /**
+     * The throwsite header identifier
+     */
+    protected static final String X_THROWSITE = "x-throwsite";
+
+    /**
+     * The response headers.
+     */
+    private final List<String> mResponseHeaders;
+
+    /**
      * The OneDriveError response.
      */
     private final OneDriveErrorResponse mError;
@@ -107,11 +117,6 @@ public class OneDriveServiceException extends ClientException {
     private final String mResponseMessage;
 
     /**
-     * The response headers.
-     */
-    private final List<String> mResponseHeaders;
-
-    /**
      * Create a OneDrive service exception.
      * @param method The method that caused the exception.
      * @param url The url.
@@ -144,6 +149,14 @@ public class OneDriveServiceException extends ClientException {
     @Override
     public String getMessage() {
         return getMessage(false);
+    }
+
+    /**
+     * The response headers.
+     * @return The list of response headers
+     */
+    public List<String> getResponseHeaders() {
+        return mResponseHeaders;
     }
 
     /**
@@ -192,7 +205,7 @@ public class OneDriveServiceException extends ClientException {
             if (verbose) {
                 sb.append(header).append(NEW_LINE);
             } else {
-                if (header.toLowerCase(Locale.ROOT).startsWith("x-throwsite")) {
+                if (header.toLowerCase(Locale.ROOT).startsWith(X_THROWSITE)) {
                     sb.append(header).append(NEW_LINE);
                 }
             }
@@ -295,7 +308,7 @@ public class OneDriveServiceException extends ClientException {
             error.error.innererror.code = ex.getMessage();
         }
 
-        if (responseCode >= INTERNAL_SERVER_ERROR) {
+        if (responseCode == INTERNAL_SERVER_ERROR) {
             return new OneDriveFatalServiceException(method,
                                                      url,
                                                      requestHeaders,


### PR DESCRIPTION
Only mark 500 exceptions as needed to be reported to the team, since the
rest of the exceptions of that class will be network related.  Also change
the default message to include the throwsite id in the message for faster
debugging

Found with #43 
