### PR TITLE
Handle error responses that are not json in nature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ mavenGroupId         = com.onedrive.sdk
 mavenArtifactId      = onedrive-sdk-android
 mavenMajorVersion    = 1
 mavenMinorVersion    = 1
-mavenPatchVersion    = 4
+mavenPatchVersion    = 5
 nightliesUrl         = http://dl.bintray.com/onedrive/Maven

--- a/onedrivesdk/src/androidTest/java/com/onedrive/sdk/http/DefaultHttpProviderTests.java
+++ b/onedrivesdk/src/androidTest/java/com/onedrive/sdk/http/DefaultHttpProviderTests.java
@@ -306,7 +306,9 @@ public class DefaultHttpProviderTests extends AndroidTestCase {
 
             @Override
             public Map<String, String> getHeaders() {
-                return new HashMap<>();
+                final HashMap<String, String> headers = new HashMap<>();
+                headers.put("Content-Type", "application/json");
+                return headers;
             }
         };
         mProvider.setConnectionFactory(new MockSingleConnectionFactory(new TestDataConnection(data)));

--- a/onedrivesdk/src/main/java/com/onedrive/sdk/http/DefaultHttpProvider.java
+++ b/onedrivesdk/src/main/java/com/onedrive/sdk/http/DefaultHttpProvider.java
@@ -48,6 +48,16 @@ import java.util.Scanner;
 public class DefaultHttpProvider implements IHttpProvider {
 
     /**
+     * The content type header
+     */
+    static final String ContentTypeHeaderName = "Content-Type";
+
+    /**
+     * The content type for json responses
+     */
+    static final String JsonContentType = "application/json";
+
+    /**
      * The serializer.
      */
     private final ISerializer mSerializer;
@@ -171,10 +181,8 @@ public class DefaultHttpProvider implements IHttpProvider {
                                                       final IProgressCallback<Result> progress)
             throws ClientException {
         final int defaultBufferSize = 4096;
-        final String contentTypeHeaderName = "Content-Type";
         final String contentLengthHeaderName = "Content-Length";
         final String binaryContentType = "application/octet-stream";
-        final String jsonContentType = "application/json";
         final int httpClientErrorResponseCode = 400;
         final int httpNoBodyResponseCode = 204;
         final int httpAcceptedResponseCode = 202;
@@ -203,13 +211,13 @@ public class DefaultHttpProvider implements IHttpProvider {
                 } else if (serializable instanceof byte[]) {
                     mLogger.logDebug("Sending byte[] as request body");
                     bytesToWrite = (byte[]) serializable;
-                    connection.addRequestHeader(contentTypeHeaderName, binaryContentType);
+                    connection.addRequestHeader(ContentTypeHeaderName, binaryContentType);
                     connection.addRequestHeader(contentLengthHeaderName, "" + bytesToWrite.length);
                 } else {
                     mLogger.logDebug("Sending " + serializable.getClass().getName() + " as request body");
                     final String serializeObject = mSerializer.serializeObject(serializable);
                     bytesToWrite = serializeObject.getBytes();
-                    connection.addRequestHeader(contentTypeHeaderName, jsonContentType);
+                    connection.addRequestHeader(ContentTypeHeaderName, JsonContentType);
                     connection.addRequestHeader(contentLengthHeaderName, "" + bytesToWrite.length);
                 }
 
@@ -273,8 +281,8 @@ public class DefaultHttpProvider implements IHttpProvider {
 
                 final Map<String, String> headers = connection.getHeaders();
 
-                final String contentType = headers.get(contentTypeHeaderName);
-                if (contentType.contains(jsonContentType)) {
+                final String contentType = headers.get(ContentTypeHeaderName);
+                if (contentType.contains(JsonContentType)) {
                     mLogger.logDebug("Response json");
                     return handleJsonResponse(in, resultClass);
                 } else {

--- a/onedrivesdk/src/main/java/com/onedrive/sdk/http/OneDriveServiceException.java
+++ b/onedrivesdk/src/main/java/com/onedrive/sdk/http/OneDriveServiceException.java
@@ -300,7 +300,8 @@ public class OneDriveServiceException extends ClientException {
         OneDriveErrorResponse error = null;
         Exception parsingException = null;
 
-        if (headers.get(DefaultHttpProvider.ContentTypeHeaderName).contains(DefaultHttpProvider.JsonContentType)) {
+        final String contentType = headers.get(DefaultHttpProvider.ContentTypeHeaderName);
+        if (contentType != null && contentType.contains(DefaultHttpProvider.JsonContentType)) {
             try {
                 error = serializer.deserializeObject(rawOutput, OneDriveErrorResponse.class);
             } catch (final Exception ex) {


### PR DESCRIPTION
Some error messages that can comeback from the service can be in non-json
formats.  Malformed URLs are an example of an error that can return this
kind of message.  Instead of assuming all messages are json, instead check
the content-type header and write the raw error message info on toString
for the exception details.

Fixes #53
